### PR TITLE
Add ability to assign tasks to lists

### DIFF
--- a/app/assets/stylesheets/lists.scss
+++ b/app/assets/stylesheets/lists.scss
@@ -1,0 +1,20 @@
+.lists {
+  display: flex;
+}
+
+.list {
+  border: 1px solid #000;
+  flex: 1;
+  max-width: 250px;
+  padding: 15px;
+
+  &:not(:last-child) {
+    margin-right: 15px;
+  }
+}
+
+.list-actions {
+  a {
+    display: block;
+  }
+}

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,0 +1,58 @@
+class ListsController < ApplicationController
+  before_action :set_list, only: [:show, :edit, :update, :destroy]
+
+  # GET /lists
+  def index
+    @lists = List.all
+  end
+
+  # GET /lists/1
+  def show
+  end
+
+  # GET /lists/new
+  def new
+    @list = List.new
+  end
+
+  # GET /lists/1/edit
+  def edit
+  end
+
+  # POST /lists
+  def create
+    @list = List.new(list_params)
+
+    if @list.save
+      redirect_to @list, notice: 'List was successfully created.'
+    else
+      render :new
+    end
+  end
+
+  # PATCH/PUT /lists/1
+  def update
+    if @list.update(list_params)
+      redirect_to @list, notice: 'List was successfully updated.'
+    else
+      render :edit
+    end
+  end
+
+  # DELETE /lists/1
+  def destroy
+    @list.destroy
+    redirect_to lists_url, notice: 'List was successfully destroyed.'
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_list
+      @list = List.find(params[:id])
+    end
+
+    # Only allow a trusted parameter "white list" through.
+    def list_params
+      params.require(:list).permit(:name)
+    end
+end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,58 +1,50 @@
 class ListsController < ApplicationController
   before_action :set_list, only: [:show, :edit, :update, :destroy]
 
-  # GET /lists
   def index
     @lists = List.all
   end
 
-  # GET /lists/1
   def show
   end
 
-  # GET /lists/new
   def new
     @list = List.new
   end
 
-  # GET /lists/1/edit
   def edit
   end
 
-  # POST /lists
   def create
     @list = List.new(list_params)
 
     if @list.save
-      redirect_to @list, notice: 'List was successfully created.'
+      redirect_to @list, notice: "List was successfully created."
     else
       render :new
     end
   end
 
-  # PATCH/PUT /lists/1
   def update
     if @list.update(list_params)
-      redirect_to @list, notice: 'List was successfully updated.'
+      redirect_to @list, notice: "List was successfully updated."
     else
       render :edit
     end
   end
 
-  # DELETE /lists/1
   def destroy
     @list.destroy
-    redirect_to lists_url, notice: 'List was successfully destroyed.'
+    redirect_to lists_url, notice: "List was successfully destroyed."
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_list
-      @list = List.find(params[:id])
-    end
 
-    # Only allow a trusted parameter "white list" through.
-    def list_params
-      params.require(:list).permit(:name)
-    end
+  def set_list
+    @list = List.find(params[:id])
+  end
+
+  def list_params
+    params.require(:list).permit(:name)
+  end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -53,6 +53,6 @@ class TasksController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def task_params
-      params.require(:task).permit(:description, :due_date, :complete)
+      params.require(:task).permit(:description, :due_date, :complete, :list_id)
     end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,58 +1,50 @@
 class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
-  # GET /tasks
   def index
     @tasks = Task.all
   end
 
-  # GET /tasks/1
   def show
   end
 
-  # GET /tasks/new
   def new
     @task = Task.new
   end
 
-  # GET /tasks/1/edit
   def edit
   end
 
-  # POST /tasks
   def create
     @task = Task.new(task_params)
 
     if @task.save
-      redirect_to @task, notice: 'Task was successfully created.'
+      redirect_to @task, notice: "Task was successfully created."
     else
       render :new
     end
   end
 
-  # PATCH/PUT /tasks/1
   def update
     if @task.update(task_params)
-      redirect_to @task, notice: 'Task was successfully updated.'
+      redirect_to @task, notice: "Task was successfully updated."
     else
       render :edit
     end
   end
 
-  # DELETE /tasks/1
   def destroy
     @task.destroy
-    redirect_to tasks_url, notice: 'Task was successfully destroyed.'
+    redirect_to tasks_url, notice: "Task was successfully destroyed."
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_task
-      @task = Task.find(params[:id])
-    end
 
-    # Only allow a trusted parameter "white list" through.
-    def task_params
-      params.require(:task).permit(:description, :due_date, :complete, :list_id)
-    end
+  def set_task
+    @task = Task.find(params[:id])
+  end
+
+  def task_params
+    params.require(:task).permit(:description, :due_date, :complete, :list_id)
+  end
 end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,0 +1,2 @@
+class List < ApplicationRecord
+end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,2 +1,4 @@
 class List < ApplicationRecord
+  belongs_to :user
+  has_many :tasks
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,2 +1,4 @@
 class Task < ApplicationRecord
+  belongs_to :list
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  has_many :tasks, dependent: :destroy
+  has_many :lists, dependent: :destroy
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
   <%= stylesheet_link_tag :application, media: "all" %>
   <%= csrf_meta_tags %>
 </head>
-<body class="<%= body_class %>">
+<body>
   <%= render "flashes" -%>
   <%= yield %>
   <%= render "javascript" %>

--- a/app/views/lists/_form.html.slim
+++ b/app/views/lists/_form.html.slim
@@ -1,0 +1,13 @@
+= form_for @list do |f|
+  - if @list.errors.any?
+    #error_explanation
+      h2 = "#{pluralize(@list.errors.count, "error")} prohibited this list from being saved:"
+      ul
+        - @list.errors.full_messages.each do |message|
+          li = message
+
+  .field
+    = f.label :name
+    = f.text_field :name
+
+  .actions = f.submit

--- a/app/views/lists/edit.html.slim
+++ b/app/views/lists/edit.html.slim
@@ -1,0 +1,8 @@
+h1 Editing list
+
+== render 'form'
+
+= link_to 'Show', @list
+'|
+= link_to 'Back', lists_path
+

--- a/app/views/lists/index.html.slim
+++ b/app/views/lists/index.html.slim
@@ -1,0 +1,20 @@
+h1 Listing lists
+
+table
+  thead
+    tr
+      th
+      th
+      th
+
+  tbody
+    - @lists.each do |list|
+      tr
+        td = list.name
+        td = link_to 'Show', list
+        td = link_to 'Edit', edit_list_path(list)
+        td = link_to 'Destroy', list, data: { confirm: 'Are you sure?' }, method: :delete
+
+br
+
+= link_to 'New List', new_list_path

--- a/app/views/lists/index.html.slim
+++ b/app/views/lists/index.html.slim
@@ -12,9 +12,9 @@ section.lists
           - else
             = link_to "No tasks yet.  Create one!", new_task_path
         .list-actions
-          = link_to 'Show', list
-          = link_to 'Edit', edit_list_path(list)
-          = link_to 'Destroy', list, data: { confirm: 'Are you sure?' }, method: :delete
+          = link_to "Show", list
+          = link_to "Edit", edit_list_path(list)
+          = link_to "Destroy", list, data: { confirm: "Are you sure?" }, method: :delete
 
 
 

--- a/app/views/lists/index.html.slim
+++ b/app/views/lists/index.html.slim
@@ -10,7 +10,11 @@ table
   tbody
     - @lists.each do |list|
       tr
-        td = list.name
+        td
+          = list.name
+          ul
+           - list.tasks.each do |task|
+            li = task.description
         td = link_to 'Show', list
         td = link_to 'Edit', edit_list_path(list)
         td = link_to 'Destroy', list, data: { confirm: 'Are you sure?' }, method: :delete

--- a/app/views/lists/index.html.slim
+++ b/app/views/lists/index.html.slim
@@ -1,23 +1,22 @@
-h1 Listing lists
+h1 My Lists
 
-table
-  thead
-    tr
-      th
-      th
-      th
+section.lists
+  - @lists.each do |list|
+    .list
+        .list-name = list.name
+        ul.tasks
+          - if list.tasks.present?
+            - list.tasks.each do |task|
+              li.task
+                = link_to "Task #{task.id}: #{task.description}", task_path(task)
+          - else
+            = link_to "No tasks yet.  Create one!", new_task_path
+        .list-actions
+          = link_to 'Show', list
+          = link_to 'Edit', edit_list_path(list)
+          = link_to 'Destroy', list, data: { confirm: 'Are you sure?' }, method: :delete
 
-  tbody
-    - @lists.each do |list|
-      tr
-        td
-          = list.name
-          ul
-           - list.tasks.each do |task|
-            li = task.description
-        td = link_to 'Show', list
-        td = link_to 'Edit', edit_list_path(list)
-        td = link_to 'Destroy', list, data: { confirm: 'Are you sure?' }, method: :delete
+
 
 br
 

--- a/app/views/lists/new.html.slim
+++ b/app/views/lists/new.html.slim
@@ -1,0 +1,5 @@
+h1 New list
+
+== render 'form'
+
+= link_to 'Back', lists_path

--- a/app/views/lists/show.html.slim
+++ b/app/views/lists/show.html.slim
@@ -1,0 +1,6 @@
+p#notice = notice
+
+
+= link_to 'Edit', edit_list_path(@list)
+'|
+= link_to 'Back', lists_path

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -15,4 +15,8 @@
   .field
     = f.label :complete
     = f.check_box :complete
+
+  .field
+    = f.collection_select :list_id, List.all, :id, :name
+
   .actions = f.submit

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -6,6 +6,7 @@ table
       th Description
       th Due date
       th Complete
+      th List
       th
       th
       th
@@ -16,6 +17,7 @@ table
         td = task.description
         td = task.due_date
         td = task.complete
+        td = task.list.name
         td = link_to 'Show', task
         td = link_to 'Edit', edit_task_path(task)
         td = link_to 'Destroy', task, data: { confirm: 'Are you sure?' }, method: :delete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ Rails.application.routes.draw do
 
   devise_for :users
 
-  root to: "taskopolis#index"
+  root to: "lists#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
+  resources :lists
   resources :tasks
+
   devise_for :users
 
   root to: "taskopolis#index"

--- a/db/migrate/20170617061818_create_lists.rb
+++ b/db/migrate/20170617061818_create_lists.rb
@@ -1,0 +1,9 @@
+class CreateLists < ActiveRecord::Migration[5.0]
+  def change
+    create_table :lists do |t|
+      t.string :name
+      t.belongs_to :user, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170617062531_add_associations_to_tasks.rb
+++ b/db/migrate/20170617062531_add_associations_to_tasks.rb
@@ -1,0 +1,6 @@
+class AddAssociationsToTasks < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :tasks, :user, foreign_key: true
+    add_reference :tasks, :list, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170615000325) do
+ActiveRecord::Schema.define(version: 20170617062531) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "lists", force: :cascade do |t|
+    t.string   "name"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_lists_on_user_id", using: :btree
+  end
 
   create_table "tasks", force: :cascade do |t|
     t.string   "description"
@@ -21,6 +29,10 @@ ActiveRecord::Schema.define(version: 20170615000325) do
     t.boolean  "complete"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.integer  "user_id"
+    t.integer  "list_id"
+    t.index ["list_id"], name: "index_tasks_on_list_id", using: :btree
+    t.index ["user_id"], name: "index_tasks_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade do |t|
@@ -40,4 +52,6 @@ ActiveRecord::Schema.define(version: 20170615000325) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  add_foreign_key "tasks", "lists"
+  add_foreign_key "tasks", "users"
 end

--- a/spec/controllers/lists_controller_spec.rb
+++ b/spec/controllers/lists_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ListsController, type: :controller do
+
+end

--- a/spec/controllers/lists_controller_spec.rb
+++ b/spec/controllers/lists_controller_spec.rb
@@ -1,5 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ListsController, type: :controller do
-
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,16 +1,17 @@
 FactoryGirl.define do
   factory :list do
-    
   end
+
   factory :list do
     name "MyString"
   end
+
   factory :task do
     description "MyString"
     due_date "2017-06-14 20:03:25"
     complete false
   end
+
   factory :user do
-    
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,10 @@
 FactoryGirl.define do
+  factory :list do
+    
+  end
+  factory :list do
+    name "MyString"
+  end
   factory :task do
     description "MyString"
     due_date "2017-06-14 20:03:25"

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe List, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe List, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"


### PR DESCRIPTION
This PR sets the foundation for the to-do list functionality.

This also makes the following changes:

1. Sets the default route to `lists#index`
2. Adds a view to show all lists and associated tasks
3.  Creates an association between `Users`, `Tasks`, and `Lists`

[ch26]