### PR TITLE
Update migration to only drop :delayed_jobs table if it exists

### DIFF
--- a/db/migrate/20170619230452_remove_delayed_jobs.rb
+++ b/db/migrate/20170619230452_remove_delayed_jobs.rb
@@ -1,5 +1,7 @@
 class RemoveDelayedJobs < ActiveRecord::Migration[5.0]
-  def change
-  	drop_table :delayed_jobs
+  if table_exists?(:delayed_jobs)
+    def change
+    	drop_table :delayed_jobs
+    end
   end
 end

--- a/db/migrate/20170619230452_remove_delayed_jobs.rb
+++ b/db/migrate/20170619230452_remove_delayed_jobs.rb
@@ -1,7 +1,7 @@
 class RemoveDelayedJobs < ActiveRecord::Migration[5.0]
   if table_exists?(:delayed_jobs)
     def change
-    	drop_table :delayed_jobs
+      drop_table :delayed_jobs
     end
   end
 end


### PR DESCRIPTION
### Why
The delayed_jobs table only exists in some of our local environments.  The automated post-deploy migrations error on this table since it doesn't exist on the staging/production servers.

### This PR
This PR will only drop the table if it exists.