### PR TITLE
Remove unused gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ ruby "2.3.1"
 
 gem "autoprefixer-rails"
 gem "flutie"
-gem "honeybadger"
 gem "jquery-rails"
 gem "normalize-rails", "~> 3.0.0"
 gem "pg"
@@ -14,7 +13,6 @@ gem "rails", "~> 5.0.0"
 gem "recipient_interceptor"
 gem "sass-rails", "~> 5.0"
 gem "simple_form"
-gem "skylight"
 gem "sprockets", ">= 3.0.0"
 gem "suspenders"
 gem "title"
@@ -50,7 +48,7 @@ group :development, :staging do
 end
 
 group :test do
-  gem "capybara-webkit"
+  gem "capybara"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,9 +67,6 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-webkit (1.11.1)
-      capybara (>= 2.3.0, < 2.8.0)
-      json
     coderay (1.1.1)
     concurrent-ruby (1.0.4)
     crack (0.4.3)
@@ -124,7 +121,6 @@ GEM
       guard-compat (~> 1.0)
       multi_json (~> 1.8)
     hashdiff (0.3.2)
-    honeybadger (2.7.2)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     jquery-rails (4.2.2)
@@ -251,8 +247,6 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    skylight (1.0.1)
-      activesupport (>= 3.0.0)
     slim (3.0.7)
       temple (~> 0.7.6)
       tilt (>= 1.3.3, < 2.1)
@@ -314,7 +308,7 @@ DEPENDENCIES
   awesome_print
   bullet
   bundler-audit (>= 0.5.0)
-  capybara-webkit
+  capybara
   database_cleaner
   devise
   dotenv-rails
@@ -323,7 +317,6 @@ DEPENDENCIES
   formulaic
   guard
   guard-livereload
-  honeybadger
   jquery-rails
   launchy
   listen
@@ -345,7 +338,6 @@ DEPENDENCIES
   shoulda-matchers
   simple_form
   simplecov
-  skylight
   slim
   slim-rails
   spring


### PR DESCRIPTION
Skylight and Honeybadger are both logging/reporting applications included with Suspenders by default.  Skylight has a free tier that we might consider in the future.  Neither of these are that helpful now.  We should re-consider when we need this sort of tool.

Removing for now to reduce the random warnings during deployment.

Resolves https://app.clubhouse.io/zapdigital/story/55/remove-unused-gems