### PR TITLE
Add UI to allow updating completion status of a task

### DIFF
--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -1,0 +1,12 @@
+.tasks {
+  list-style: none;
+  padding: 0;
+}
+
+.task-complete-checkbox {
+  &:checked {
+    ~ a {
+      text-decoration: line-through;
+    }
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception
+  protect_from_forgery
 end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -7,6 +7,7 @@ class ListsController < ApplicationController
   end
 
   def show
+    @tasks = @list.tasks.order(:complete)
   end
 
   def new

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -4,5 +4,4 @@ class Task < ApplicationRecord
 
   validates :description, presence: true
   validates :due_date, presence: true
-
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,8 @@
 class Task < ApplicationRecord
   belongs_to :list
   belongs_to :user
+
+  validates :description, presence: true
+  validates :due_date, presence: true
+
 end

--- a/app/views/lists/index.html.slim
+++ b/app/views/lists/index.html.slim
@@ -18,7 +18,7 @@ section.lists
                   noscript
                     = f.submit
 
-                  = link_to "Task #{task.id}: #{task.description}", task_path(task), class: ('completed' if task.complete?)
+                  = link_to "#{task.description}", task_path(task), class: ('completed' if task.complete?)
           - else
             = link_to "No tasks yet.  Create one!", new_task_path
         .list-actions

--- a/app/views/lists/index.html.slim
+++ b/app/views/lists/index.html.slim
@@ -6,9 +6,19 @@ section.lists
         .list-name = link_to list.name, list_path(list)
         ul.tasks
           - if list.tasks.present?
-            - list.tasks.each do |task|
-              li.task
-                = link_to "Task #{task.id}: #{task.description}", task_path(task)
+            - list.tasks.order(:complete).each do |task|
+              = form_for task, remote: true do |f|
+                - if task.errors.any?
+                  #error_explanation
+                    ul
+                      - task.errors.full_messages.each do |message|
+                        li = message
+                li.task
+                  = f.check_box :complete, onChange: "$(this.form).submit()", class: "task-complete-checkbox"
+                  noscript
+                    = f.submit
+
+                  = link_to "Task #{task.id}: #{task.description}", task_path(task), class: ('completed' if task.complete?)
           - else
             = link_to "No tasks yet.  Create one!", new_task_path
         .list-actions

--- a/app/views/lists/show.html.slim
+++ b/app/views/lists/show.html.slim
@@ -5,10 +5,20 @@ section.lists
   .list
       .list-name = @list.name
       ul.tasks
-        - if @list.tasks.present?
-          - @list.tasks.each do |task|
-            li.task
-              = link_to "Task #{task.id}: #{task.description}", task_path(task)
+        - if @tasks.present?
+          - @tasks.order(:complete).each do |task|
+            = form_for task, remote: true do |f|
+              - if task.errors.any?
+                #error_explanation
+                  ul
+                    - task.errors.full_messages.each do |message|
+                      li = message
+              li.task
+                = f.check_box :complete, onChange: "$(this.form).submit()", class: "task-complete-checkbox"
+                noscript
+                  = f.submit
+
+                = link_to "Task #{task.id}: #{task.description}", task_path(task), class: ('completed' if task.complete?)
         - else
           = link_to "No tasks yet.  Create one!", new_task_path
       .list-actions

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -12,6 +12,7 @@
   .field
     = f.label :due_date
     = f.datetime_select :due_date
+
   .field
     = f.label :complete
     = f.check_box :complete

--- a/db/migrate/20170615000325_create_tasks.rb
+++ b/db/migrate/20170615000325_create_tasks.rb
@@ -3,7 +3,7 @@ class CreateTasks < ActiveRecord::Migration[5.0]
     create_table :tasks do |t|
       t.string :description
       t.datetime :due_date
-      t.boolean :complete, default: 0
+      t.boolean :complete
 
       t.timestamps
     end

--- a/db/migrate/20170615000325_create_tasks.rb
+++ b/db/migrate/20170615000325_create_tasks.rb
@@ -3,7 +3,7 @@ class CreateTasks < ActiveRecord::Migration[5.0]
     create_table :tasks do |t|
       t.string :description
       t.datetime :due_date
-      t.boolean :complete
+      t.boolean :complete, default: 0
 
       t.timestamps
     end


### PR DESCRIPTION
This adds the ability for users to mark tasks as complete.  The checkbox submits a `PATCH` action remotely to update the `complete` boolean field.

For now, task lists are sorted by completion status and show all tasks.  We'll eventually want to filter out "completed" tasks.

![2017-06-23 08_30_10](https://user-images.githubusercontent.com/232278/27482160-3d2955ce-57ee-11e7-978d-b8d034421a65.gif)
