### PR TITLE
Remove EMAIL_RECIPIENTS from app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,9 +7,6 @@
     "APPLICATION_HOST":{
       "required":true
     },
-    "EMAIL_RECIPIENTS":{
-      "required":true
-    },
     "HEROKU_APP_NAME": {
       "required":true
     },


### PR DESCRIPTION
This config variable is no longer required in the code and has been removed from the staging and production environments.  Including it the app.json configuration prevents the Heroku pipeline from staging PR branches. 