### PR TITLE
Set minimum of value of seed-created resources to 1

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,9 +23,10 @@ User.create(email: "admin@taskopolis.com",
             admin: true)
 
 # Resources
+Resource.destroy_all
 resources = ["Wood", "Steel", "Stone", "Glass", "Bricks"]
 resources.each_with_index do |resource, index|
-  Resource.create(name: resources[index], value: index * 100)
+  Resource.create(name: resources[index], value: [(index  * 100), 1].max)
 end
 
 # Lists & Tasks


### PR DESCRIPTION
When `Resources` are created via the seed, the first resource ("Wood") was being created with an initial value of 0. This changes sets a minimum of 1.

I've also added a line to delete all resources when seeded and re-generate them.